### PR TITLE
Add StockDory

### DIFF
--- a/configs/stockdory.json
+++ b/configs/stockdory.json
@@ -1,0 +1,7 @@
+{
+    "command": "/data/generic.sh stockdory CPU",
+    "options": {
+        "Threads": 250,
+        "Hash": 16384
+    }
+}

--- a/dockers/stockdory.Dockerfile
+++ b/dockers/stockdory.Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install prerequisites
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    lsb-release \
+    software-properties-common \
+    gnupg \
+    curl \
+    git \
+    build-essential \
+    cmake \
+    ninja-build \
+    python3 \
+    python3-pip \
+    python3-venv \
+    wget
+
+
+# Install LLVM 20
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh 20 && \
+    rm -rf llvm.sh
+
+
+# Set up LLVM environment
+RUN ln -s /usr/bin/clang-20 /usr/bin/clang && \
+    ln -s /usr/bin/clang++-20 /usr/bin/clang++
+
+
+# Set environment variables for LLVM
+ENV CC=clang
+ENV CXX=clang++
+
+# Clone StockDory
+RUN git clone https://github.com/TheBlackPlague/StockDory
+
+# Change to StockDory directory
+WORKDIR /StockDory
+
+# Run Makefile to build StockDory
+RUN make CC=clang CXX=clang++ EXE=StockDory
+
+# Launch StockDory
+CMD ["./StockDory"]


### PR DESCRIPTION
This PR adds a configuration file and a Dockerfile to set up and run the StockDory engine. It aligns with how the other engine's Dockerfiles and configuration are set up.

### Configuration for StockDory:

* Added a new configuration file, `configs/stockdory.json`, specifying the command to run StockDory with the CPU backend, along with options for thread count (`Threads: 250`) and hash size (`Hash: 16384`).

### Docker environment setup:

* Created a new Dockerfile, `dockers/stockdory.Dockerfile`, to build and run StockDory. Key steps include:
  - Using `ubuntu:24.04` as the base image.
  - Installing prerequisites and the compiler.
  - Cloning the StockDory repository and building the engine.
  - Configuring the Docker container to launch StockDory upon startup.