### PR TITLE
Update Berserk to build with PGO

### DIFF
--- a/dockers/berserk.Dockerfile
+++ b/dockers/berserk.Dockerfile
@@ -17,6 +17,6 @@ ARG CACHE_BUST
 RUN git clone https://github.com/jhonnold/berserk.git && \
     cd berserk/src && \
     git checkout main && \
-    make build -j ARCH=native EXE=berserk CC=clang
+    make pgo -j ARCH=native EXE=berserk CC=clang
 
 CMD [ "./berserk/src/berserk" ]


### PR DESCRIPTION
PGO has shown to be a better build method for Berserk. Verified `pgo` can build without need for additional dependencies.

```
[+] Building 80.4s (8/8) FINISHED                                                                                                           docker:default
 => [internal] load build definition from berserk.Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 688B                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                       1.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [1/4] FROM docker.io/library/ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee                                 1.4s
 => => resolve docker.io/library/ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee                                 0.0s
 => => sha256:89dc6ea4eae2b38a3550534ece4983005a7d2e90e4fa503ed04dcfc58ee71159 29.53MB / 29.53MB                                                      0.5s
 => => sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee 6.69kB / 6.69kB                                                        0.0s
 => => sha256:6f63292a7444f9346bf6ec6816dd93029dae021ee00cabb564c440417519680c 424B / 424B                                                            0.0s
 => => sha256:b103ac8bf22ec7fe2abe740f86dccd1e7d086e0ad8d064d07bd9c8a7961a5d7a 2.29kB / 2.29kB                                                        0.0s
 => => extracting sha256:89dc6ea4eae2b38a3550534ece4983005a7d2e90e4fa503ed04dcfc58ee71159                                                             0.8s
 => [2/4] RUN apt update && apt-get -y install git make cmake wget curl gcc g++ clang llvm lld                                                       27.0s
 => [3/4] RUN apt update && apt-get -y install jq                                                                                                     3.7s 
 => [4/4] RUN git clone https://github.com/jhonnold/berserk.git &&     cd berserk/src &&     git checkout main &&     make pgo -j ARCH=native EXE=b  45.0s 
 => exporting to image                                                                                                                                2.2s 
 => => exporting layers                                                                                                                               2.2s 
 => => writing image sha256:fb3271fea3b897b8081c9a2f11f83ac5bb825454575eeaa77e536ff4dddd2191                                                          0.0s 
 => => naming to docker.io/jhonnold/berserk                                                                                                           0.0s
 ```