### PR TITLE
Use all 250 threads for Tcheran

### DIFF
--- a/configs/tcheran.json
+++ b/configs/tcheran.json
@@ -1,7 +1,7 @@
 {
     "command": "/data/engines/tcheran.sh",
     "options": {
-        "Threads": 32,
+        "Threads": 250,
         "Hash": 16384,
         "SyzygyPath": "/data/tablebases"
     }


### PR DESCRIPTION
Looks like 30 is left over from the previous round of testing in February when the max supported thread count was not high enough.